### PR TITLE
Add prometheus config node

### DIFF
--- a/docker-local/library/prometheus/playbooks/config_create.yml
+++ b/docker-local/library/prometheus/playbooks/config_create.yml
@@ -1,0 +1,12 @@
+- hosts: all
+  gather_facts: yes
+  become: yes
+  tasks:
+    - name: Ensure dir exists
+      file:
+        path: "{{ dest | dirname }}"
+        state: directory
+    - name: Create config file
+      template:
+        src: "prometheus.yaml.tmpl"
+        dest: "{{ dest }}"

--- a/docker-local/library/prometheus/playbooks/templates/prometheus.yaml.tmpl
+++ b/docker-local/library/prometheus/playbooks/templates/prometheus.yaml.tmpl
@@ -1,0 +1,4 @@
+- job_name: skydive-connector
+    scrape_interval: 5s
+    static_configs:
+            - targets: ['{{ target_address }}']

--- a/docker-local/library/prometheus/prometheus_config.yaml
+++ b/docker-local/library/prometheus/prometheus_config.yaml
@@ -1,0 +1,25 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  sodalite.nodes.skydive-connector.config:
+    derived_from: tosca.nodes.SoftwareComponent
+    description: Node for creation of skydive config file
+    properties:
+      dest:
+        type: string
+        description: Destintation of config file on target VM
+      target_address:
+        type: string
+        description: ip address of skydive connector
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create:
+            inputs:
+              dest:                { default: { get_property: [ SELF, dest ] }, type: string }
+              target_address:          { default: { get_property: [ SELF, target_address ] }, type: string }
+            implementation:
+              primary: playbooks/config_create.yml
+              dependencies:
+                - playbooks/templates/prometheus.yaml.tmpl

--- a/docker-local/service.yaml
+++ b/docker-local/service.yaml
@@ -8,6 +8,7 @@ imports:
   - modules/docker/docker_component.yaml
   - modules/docker/docker_certificate.yaml
   - modules/misc/ssh/types.yaml
+  - library/prometheus/prometheus_config.yaml
 
 node_types:
 
@@ -414,6 +415,14 @@ topology_template:
 
     # monitoring-system
     # https://github.com/SODALITE-EU/monitoring-system
+    prometheus_config:
+      type: sodalite.nodes.skydive-connector.config
+      properties:
+        dest: /tmp/prometheus/prometheus.yml
+        target_address: http://skydive-analyzer:9101
+      requirements:
+        - dependency: skydive-analyzer
+
     prometheus-container:
       type: sodalite.nodes.DockerizedComponent
       properties:
@@ -429,6 +438,7 @@ topology_template:
         - host: docker-host
         - registry: docker-public-registry
         - network: docker-network
+        - dependency: prometheus_config
 
     # skydive-analyzer
     # https://github.com/skydive-project/skydive


### PR DESCRIPTION
This PR adds prometheus_config node, which creates prometheus.yml config file from a template and adds it target_address.

Since both components, prometheus and skydive, are part of the same docker-network, `address-of-skydive-prometheus-connector` can be set to `http://skydive-analyzer:9101` (skydive-analyzer is alias of targeted docker container) and components will  be connected.

[POC for prometheus_config node](https://github.com/KalmanMeth/iac-platform-stack/files/5598124/prometheus-configfile-demo.zip)
